### PR TITLE
Temporarily disable the Release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     # Prevents changesets action from creating a PR on forks
     # if: github.repository == 'qiskit-community/qiskit-components'
 
+    # Temporarily disabled
+    if: false
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We need to setup the NPM token to avoid the GitHub Action failures.