### PR TITLE
Add missed tslib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rollup": "^2.54.0",
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-postcss-lit": "^1.1.0",
+    "tslib": "^2.3.0",
     "typescript": "~4.3.5"
   },
   "eslintConfig": {


### PR DESCRIPTION
Will fix the warning:

>warning " > @rollup/plugin-typescript@8.2.3" has unmet peer dependency "tslib@*".